### PR TITLE
chore: add .debug suffix to debug app id to allow simultaneous installation of debug and release build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,9 @@ configure<ApplicationExtension> {
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+        debug {
+            applicationIdSuffix = ".debug"
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
I noticed that I have to uninstall the current app installation to test some stuff, with these changes it's possible to have the debug build (e.g. built from Android Studio) and the release build (e.g. from F-Droid) installed at the same time, which makes working on the app much more convenient.