### PR TITLE
feat: estimate remaining charging time on devices that don't provide charge duration estimations

### DIFF
--- a/app/src/main/java/montafra/beam/BatterySnapshot.kt
+++ b/app/src/main/java/montafra/beam/BatterySnapshot.kt
@@ -70,6 +70,24 @@ class BatterySnapshot(
         if (ms == -1L)
             return null
 
+        // on some devices, chargeTimeRemainingRaw is always 0, even when the device is charging
+        // in this case, we calculate the expected charge duration manually by
+        // assuming a linear curve (which is not really correct practically, but
+        // modeling battery charge curves is too complex for doing it here
+        if (ms == 0L && level != null && level < 0.99) {
+            if (watts != null && watts!! > 0) {
+                // energyWattHours contains the energy currently charged in the battery
+                val batteryCapacityWattHours = energyWattHours?.div(level)
+                val fullChargeDurationHours = batteryCapacityWattHours?.div(watts)
+
+                val remainingChargePercentage = 1.0 - level
+                val hoursUntilCharged = fullChargeDurationHours?.times(remainingChargePercentage)
+                return hoursUntilCharged?.times(3600)
+            }
+
+            return null
+        }
+
         return fromMillis(ms.toDouble())
     }
 }


### PR DESCRIPTION
Hey, first of all thanks for your work on this app!

Some devices (including mine) don't provide a charge time estimation via the `BatteryManager`.

Therefore, I created this patch here to estimate the charge time based on the battery capacity and the current watts. The estimation is not 100% realistic because batteries charge much slower in the 90%+ area than in the 30-70% area for example, but it's better than currently where it just says "fully charged" although the battery level is far from 100%. There's a related issue in the original Wattz repository: https://github.com/dubrowgn/wattz/issues/33.

Cheers
Bnyro